### PR TITLE
Working version for Windows

### DIFF
--- a/src/_pyhull.c
+++ b/src/_pyhull.c
@@ -506,43 +506,41 @@ struct module_state {
 };
 
 #if PY_MAJOR_VERSION >= 3
-    #define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
 #else
-    #define GETSTATE(m) (&_state)
-    static struct module_state _state;
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
 #endif
 
 #if PY_MAJOR_VERSION >= 3
 
-    static int _pyhull_traverse(PyObject *m, visitproc visit, void *arg) {
-        Py_VISIT(GETSTATE(m)->error);
-        return 0;
-    }
+static int _pyhull_traverse(PyObject *m, visitproc visit, void *arg) {
+	Py_VISIT(GETSTATE(m)->error);
+	return 0;
+}
 
-    static int _pyhull_clear(PyObject *m) {
-        Py_CLEAR(GETSTATE(m)->error);
-        return 0;
-    }
+static int _pyhull_clear(PyObject *m) {
+	Py_CLEAR(GETSTATE(m)->error);
+	return 0;
+}
 
 
-    static struct PyModuleDef moduledef = {
-            PyModuleDef_HEAD_INIT,
-            "_pyhull",
-            NULL,
-            sizeof(struct module_state),
-            QhullMethods,
-            NULL,
-            _pyhull_traverse,
-            _pyhull_clear,
-            NULL
-    };
+static struct PyModuleDef moduledef = {
+		PyModuleDef_HEAD_INIT,
+		"_pyhull",
+		NULL,
+		sizeof(struct module_state),
+		QhullMethods,
+		NULL,
+		_pyhull_traverse,
+		_pyhull_clear,
+		NULL
+};
 
-    #define INITERROR return NULL
-
+#define INITERROR return NULL
 #else
-    #define INITERROR return
+#define INITERROR return
 #endif
-
 
 #if PY_MAJOR_VERSION >= 3
 PyMODINIT_FUNC PyInit__pyhull(void)

--- a/src/_pyhull.c
+++ b/src/_pyhull.c
@@ -68,27 +68,28 @@ int isatty(int);  /* returns 1 if stdin is a tty
 #include <tchar.h>
 #define strtok_r strtok_s
 
+
 static int get_windows_temp_file()
 {
-	#define MAX_PATH 260
-	char lpTempPathBuffer[MAX_PATH];
-	char szTempFileName[MAX_PATH];
-	DWORD dwRetVal = GetTempPath(MAX_PATH, lpTempPathBuffer);
-	
-	UINT uRetVal = GetTempFileName(lpTempPathBuffer, 
+    #define MAX_PATH 260
+    char lpTempPathBuffer[MAX_PATH];
+    char szTempFileName[MAX_PATH];
+    DWORD dwRetVal = GetTempPath(MAX_PATH, lpTempPathBuffer);
+    
+    UINT uRetVal = GetTempFileName(lpTempPathBuffer, 
                               TEXT("tmp_pyhull_"),     
                               0,                
                               szTempFileName);
-							  
-	HANDLE handle = CreateFileA(szTempFileName, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY |  FILE_FLAG_DELETE_ON_CLOSE, NULL);
-	int fd = _open_osfhandle((intptr_t)handle, _O_TEXT);
-	return fd;
+                              
+    HANDLE handle = CreateFileA(szTempFileName, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY |  FILE_FLAG_DELETE_ON_CLOSE, NULL);
+    int fd = _open_osfhandle((intptr_t)handle, _O_TEXT);
+    return fd;
 }
-
 #endif
 
 char hidden_options[]=" d v H Qbb Qf Qg Qm Qr Qu Qv Qx Qz TR E V Fp Gt Q0 Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8 Q9 ";
 char qhalf_hidden_options[]=" d n v Qbb QbB Qf Qg Qm Qr QR Qv Qx Qz TR E V Fa FA FC FD FS Ft FV Gt Q0 Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8 Q9 ";
+
 
 static PyObject* py_qconvex(PyObject *self, PyObject *args) {
     const char *arg;
@@ -109,7 +110,7 @@ static PyObject* py_qconvex(PyObject *self, PyObject *args) {
     FILE* fin;
     FILE* fout;
 
-	
+    
     if (!PyArg_ParseTuple(args, "ss", &arg, &data))
         return NULL;
 
@@ -123,68 +124,68 @@ static PyObject* py_qconvex(PyObject *self, PyObject *args) {
     }
     argv[0] = "qconvex";
 
-	
+    
     /* Because qhull uses stdin and stdout streams for io, we need to create
     FILE* stream to simulate these io streams.*/
-	#if defined(_WIN32) || defined(_WIN64)
-	fin = _fdopen(get_windows_temp_file(), "w+");
-    fprintf(fin, data);	
+    #if defined(_WIN32) || defined(_WIN64)
+    fin = _fdopen(get_windows_temp_file(), "w+");
+    fprintf(fin, data);    
     fflush(fin);
-	rewind(fin);
-	fout = _fdopen(get_windows_temp_file(), "w+");
-	#else
+    rewind(fin);
+    fout = _fdopen(get_windows_temp_file(), "w+");
+    #else
     fin = fmemopen(data, strlen(data), "r");
     fout = open_memstream(&bp, &size);
-	#endif
-	
-       	
+    #endif
+    
     if ((fin == NULL) || (fout == NULL))
     {
-		return NULL;
-	}
-	/* Now do the usual qhull code (modified from qconvex.c). */
-	qh_init_A(fin, fout, stderr, argc, argv);
-	exitcode= setjmp(qh errexit);
-	if (!exitcode) {
-		qh_checkflags(qh qhull_command, hidden_options);
-		qh_initflags(qh qhull_command);
-		points= qh_readpoints(&numpoints, &dim, &ismalloc);
-		if (dim >= 5) {
-			qh_option("Qxact_merge", NULL, NULL);
-			qh MERGEexact= True;
-		}
-		qh_init_B(points, numpoints, dim, ismalloc);
-		qh_qhull();
-		qh_check_output();
-		qh_produce_output();
-		if (qh VERIFYoutput && !qh FORCEoutput && !qh STOPpoint && !qh STOPcone)
-			qh_check_points();
-		exitcode= qh_ERRnone;
-	} 
-	
-	qh NOerrexit= True;  /* no more setjmp */
-	#ifdef qh_NOmem
-	qh_freeqhull( True);
-	#else
-	qh_freeqhull( False);
-	qh_memfreeshort(&curlong, &totlong);
-	if (curlong || totlong)
-		fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory(%d pieces)\n", totlong, curlong);
-	#endif
-	
-	#if defined(_WIN32) || defined(_WIN64)
-	rewind(fout);
-	fseek(fout, 0, SEEK_END);
-	size = ftell(fout);
-	rewind(fout);
-	bp = calloc(1, size + 1);
-
-	fread(bp, 1, size, fout);
-	bp[size] = '\0';
-	#endif
-	fclose(fin);
-	fclose(fout);
-	return Py_BuildValue("s", bp);
+        return NULL;
+    }
+    /* Now do the usual qhull code (modified from qconvex.c). */
+    qh_init_A(fin, fout, stderr, argc, argv);
+    exitcode= setjmp(qh errexit);
+    if (!exitcode) {
+        qh_checkflags(qh qhull_command, hidden_options);
+        qh_initflags(qh qhull_command);
+        points= qh_readpoints(&numpoints, &dim, &ismalloc);
+        if (dim >= 5) {
+            qh_option("Qxact_merge", NULL, NULL);
+            qh MERGEexact= True;
+        }
+        qh_init_B(points, numpoints, dim, ismalloc);
+        qh_qhull();
+        qh_check_output();
+        qh_produce_output();
+        if (qh VERIFYoutput && !qh FORCEoutput && !qh STOPpoint && !qh STOPcone)
+            qh_check_points();
+        exitcode= qh_ERRnone;
+    } 
+    
+    qh NOerrexit= True;  /* no more setjmp */
+    #ifdef qh_NOmem
+    qh_freeqhull( True);
+    #else
+    qh_freeqhull( False);
+    qh_memfreeshort(&curlong, &totlong);
+    if (curlong || totlong)
+        fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory(%d pieces)\n", totlong, curlong);
+    #endif
+    #if defined(_WIN32) || defined(_WIN64)
+    
+    rewind(fout);
+    fseek(fout, 0, SEEK_END);
+    size = ftell(fout);
+    rewind(fout);
+    bp = calloc(1, size + 1);
+    fread(bp, 1, size, fout);
+    bp[size] = '\0';
+    #endif
+    
+    fclose(fin);
+    fclose(fout);
+    
+    return Py_BuildValue("s", bp);
 }
 
 
@@ -223,69 +224,69 @@ static PyObject* py_qdelaunay(PyObject *self, PyObject *args) {
 
     /* Because qhull uses stdin and stdout streams for io, we need to create
     FILE* stream to simulate these io streams.*/
-	#if defined(_WIN32) || defined(_WIN64)
-	fin = _fdopen(get_windows_temp_file(), "w+");
-    fprintf(fin, data);	
+    #if defined(_WIN32) || defined(_WIN64)
+    fin = _fdopen(get_windows_temp_file(), "w+");
+    fprintf(fin, data);    
     fflush(fin);
-	rewind(fin);
-	fout = _fdopen(get_windows_temp_file(), "w+");
-	#else
+    rewind(fin);
+    fout = _fdopen(get_windows_temp_file(), "w+");
+    #else
     fin = fmemopen(data, strlen(data), "r");
     fout = open_memstream(&bp, &size);
-	#endif
+    #endif
 
     if ((fin == NULL) || (fout == NULL))
     {
-		return NULL;
-	}
-	/* Now do the usual qhull code (modified from qdelaunay.c). */
-	qh_init_A(fin, fout, stderr, argc, argv);  /* sets qh qhull_command */
-	exitcode= setjmp(qh errexit); /* simple statement for CRAY J916 */
-	if (!exitcode) {
-		qh_option("delaunay  Qbbound-last", NULL, NULL);
-		qh DELAUNAY= True;     /* 'd'   */
-		qh SCALElast= True;    /* 'Qbb' */
-		qh KEEPcoplanar= True; /* 'Qc', to keep coplanars in 'p' */
-		qh_checkflags(qh qhull_command, hidden_options);
-		qh_initflags(qh qhull_command);
-		points= qh_readpoints(&numpoints, &dim, &ismalloc);
-		if (dim >= 5) {
-			qh_option("Qxact_merge", NULL, NULL);
-			qh MERGEexact= True; /* 'Qx' always */
-		}
-		qh_init_B(points, numpoints, dim, ismalloc);
-		qh_qhull();
-		qh_check_output();
-		qh_produce_output();
-		if (qh VERIFYoutput && !qh FORCEoutput && !qh STOPpoint && !qh STOPcone)
-			qh_check_points();
-		exitcode= qh_ERRnone;
-	}
-	qh NOerrexit= True;  /* no more setjmp */
-	#ifdef qh_NOmem
-		qh_freeqhull( True);
-	#else
-		qh_freeqhull( False);
-		qh_memfreeshort(&curlong, &totlong);
-		if (curlong || totlong)
-			fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory(%d pieces)\n",
-			totlong, curlong);
-	#endif
-
-	#if defined(_WIN32) || defined(_WIN64)
-	rewind(fout);
-	fseek(fout, 0, SEEK_END);
-	size = ftell(fout);
-	rewind(fout);
-	bp = calloc(1, size + 1);
-
-	fread(bp, 1, size, fout);
-	bp[size] = '\0';
-	#endif
-	fclose(fin);
-	fclose(fout);
-	return Py_BuildValue("s", bp);
-
+        return NULL;
+    }
+    /* Now do the usual qhull code (modified from qdelaunay.c). */
+    qh_init_A(fin, fout, stderr, argc, argv);  /* sets qh qhull_command */
+    exitcode= setjmp(qh errexit); /* simple statement for CRAY J916 */
+    if (!exitcode) {
+        qh_option("delaunay  Qbbound-last", NULL, NULL);
+        qh DELAUNAY= True;     /* 'd'   */
+        qh SCALElast= True;    /* 'Qbb' */
+        qh KEEPcoplanar= True; /* 'Qc', to keep coplanars in 'p' */
+        qh_checkflags(qh qhull_command, hidden_options);
+        qh_initflags(qh qhull_command);
+        points= qh_readpoints(&numpoints, &dim, &ismalloc);
+        if (dim >= 5) {
+            qh_option("Qxact_merge", NULL, NULL);
+            qh MERGEexact= True; /* 'Qx' always */
+        }
+        qh_init_B(points, numpoints, dim, ismalloc);
+        qh_qhull();
+        qh_check_output();
+        qh_produce_output();
+        if (qh VERIFYoutput && !qh FORCEoutput && !qh STOPpoint && !qh STOPcone)
+            qh_check_points();
+        exitcode= qh_ERRnone;
+    }
+    qh NOerrexit= True;  /* no more setjmp */
+    #ifdef qh_NOmem
+    qh_freeqhull( True);
+    #else
+    qh_freeqhull( False);
+    qh_memfreeshort(&curlong, &totlong);
+    if (curlong || totlong)
+        fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory(%d pieces)\n",
+        totlong, curlong);
+    #endif
+    #if defined(_WIN32) || defined(_WIN64)
+    
+    rewind(fout);
+    fseek(fout, 0, SEEK_END);
+    size = ftell(fout);
+    rewind(fout);
+    bp = calloc(1, size + 1);
+    fread(bp, 1, size, fout);
+    bp[size] = '\0';
+    #endif
+    
+    fclose(fin);
+    fclose(fout);
+    
+    return Py_BuildValue("s", bp);
 }
 
 
@@ -323,70 +324,68 @@ static PyObject* py_qvoronoi(PyObject *self, PyObject *args) {
 
     /* Because qhull uses stdin and stdout streams for io, we need to create
     FILE* stream to simulate these io streams.*/
-	#if defined(_WIN32) || defined(_WIN64)
-	fin = _fdopen(get_windows_temp_file(), "w+");
-    fprintf(fin, data);	
+    #if defined(_WIN32) || defined(_WIN64)
+    fin = _fdopen(get_windows_temp_file(), "w+");
+    fprintf(fin, data);    
     fflush(fin);
-	rewind(fin);
-	fout = _fdopen(get_windows_temp_file(), "w+");
-	#else
+    rewind(fin);
+    fout = _fdopen(get_windows_temp_file(), "w+");
+    #else
     fin = fmemopen(data, strlen(data), "r");
     fout = open_memstream(&bp, &size);
-	#endif
+    #endif
 
-    if ((fin == NULL) || (fout != NULL))
-		
+    if ((fin == NULL) || (fout == NULL))        
     {
-		return NULL;
-	}
-	/* Now do the usual qhull code (modified from qvoronoi.c). */
-	qh_init_A(fin, fout, stderr, argc, argv);  /* sets qh qhull_command */
-	exitcode= setjmp(qh errexit); /* simple statement for CRAY J916 */
-	if (!exitcode) {
-		qh_option("voronoi  _bbound-last  _coplanar-keep", NULL, NULL);
-		qh DELAUNAY= True;     /* 'v'   */
-		qh VORONOI= True;
-		qh SCALElast= True;    /* 'Qbb' */
-		qh_checkflags(qh qhull_command, hidden_options);
-		qh_initflags(qh qhull_command);
-		points= qh_readpoints(&numpoints, &dim, &ismalloc);
-		if (dim >= 5) {
-			qh_option("_merge-exact", NULL, NULL);
-			qh MERGEexact= True; /* 'Qx' always */
-		}
-		qh_init_B(points, numpoints, dim, ismalloc);
-		qh_qhull();
-		qh_check_output();
-		qh_produce_output();
-		if (qh VERIFYoutput && !qh FORCEoutput && !qh STOPpoint && !qh STOPcone)
-			qh_check_points();
-		exitcode= qh_ERRnone;
-	}
-	qh NOerrexit= True;  /* no more setjmp */
-	#ifdef qh_NOmem
-		qh_freeqhull( True);
-	#else
-		qh_freeqhull( False);
-		qh_memfreeshort(&curlong, &totlong);
-		if (curlong || totlong)
-			fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory(%d pieces)\n",
-			totlong, curlong);
-	#endif
-	#if defined(_WIN32) || defined(_WIN64)
-	rewind(fout);
-	fseek(fout, 0, SEEK_END);
-	size = ftell(fout);
-	rewind(fout);
-	bp = calloc(1, size + 1);
+        return NULL;
+    }
+    /* Now do the usual qhull code (modified from qvoronoi.c). */
+    qh_init_A(fin, fout, stderr, argc, argv);  /* sets qh qhull_command */
+    exitcode= setjmp(qh errexit); /* simple statement for CRAY J916 */
+    if (!exitcode) {
+        qh_option("voronoi  _bbound-last  _coplanar-keep", NULL, NULL);
+        qh DELAUNAY= True;     /* 'v'   */
+        qh VORONOI= True;
+        qh SCALElast= True;    /* 'Qbb' */
+        qh_checkflags(qh qhull_command, hidden_options);
+        qh_initflags(qh qhull_command);
+        points= qh_readpoints(&numpoints, &dim, &ismalloc);
+        if (dim >= 5) {
+            qh_option("_merge-exact", NULL, NULL);
+            qh MERGEexact= True; /* 'Qx' always */
+        }
+        qh_init_B(points, numpoints, dim, ismalloc);
+        qh_qhull();
+        qh_check_output();
+        qh_produce_output();
+        if (qh VERIFYoutput && !qh FORCEoutput && !qh STOPpoint && !qh STOPcone)
+            qh_check_points();
+        exitcode= qh_ERRnone;
+    }
+    qh NOerrexit= True;  /* no more setjmp */
+    #ifdef qh_NOmem
+    qh_freeqhull( True);
+    #else
+    qh_freeqhull( False);
+    qh_memfreeshort(&curlong, &totlong);
+    if (curlong || totlong)
+        fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory(%d pieces)\n",
+        totlong, curlong);
+    #endif
+    #if defined(_WIN32) || defined(_WIN64)
+    
+    rewind(fout);
+    fseek(fout, 0, SEEK_END);
+    size = ftell(fout);
+    rewind(fout);
+    bp = calloc(1, size + 1);
+    fread(bp, 1, size, fout);
+    bp[size] = '\0';
+    #endif
+    fclose(fin);
+    fclose(fout);
 
-	fread(bp, 1, size, fout);
-	bp[size] = '\0';
-	#endif
-	fclose(fin);
-	fclose(fout);
-
-	return Py_BuildValue("s", bp);
-
+    return Py_BuildValue("s", bp);
 }
 
 
@@ -423,68 +422,68 @@ static PyObject* py_qhalf(PyObject *self, PyObject *args) {
 
     /* Because qhull uses stdin and stdout streams for io, we need to create
      FILE* stream to simulate these io streams.*/
-	#if defined(_WIN32) || defined(_WIN64)
-	fin = _fdopen(get_windows_temp_file(), "w+");
-    fprintf(fin, data);	
+    #if defined(_WIN32) || defined(_WIN64)
+    fin = _fdopen(get_windows_temp_file(), "w+");
+    fprintf(fin, data);    
     fflush(fin);
-	rewind(fin);
-	fout = _fdopen(get_windows_temp_file(), "w+");
-	#else
+    rewind(fin);
+    fout = _fdopen(get_windows_temp_file(), "w+");
+    #else
     fin = fmemopen(data, strlen(data), "r");
     fout = open_memstream(&bp, &size);
-	#endif
+    #endif
 
     if ((fin == NULL) || (fout == NULL))
     {
-		return NULL;
-	}
-	/* Now do the usual qhull code (modified from qvoronoi.c). */
-	qh_init_A(fin, fout, stderr, argc, argv);  /* sets qh qhull_command */
-	exitcode= setjmp(qh errexit); /* simple statement for CRAY J916 */
-	if (!exitcode) {
-		qh_option("Halfspace", NULL, NULL);
-		qh HALFspace= True;    /* 'H'   */
-		qh_checkflags(qh qhull_command, qhalf_hidden_options);
-		qh_initflags(qh qhull_command);
-		if (qh SCALEinput) {
-			fprintf(qh ferr, "\
-					qhull error: options 'Qbk:n' and 'QBk:n' are not used with qhalf.\n\
-					Use 'Qbk:0Bk:0 to drop dimension k.\n");
-			qh_errexit(qh_ERRinput, NULL, NULL);
-		}
-		points= qh_readpoints(&numpoints, &dim, &ismalloc);
-		if (dim >= 5) {
-			qh_option("Qxact_merge", NULL, NULL);
-			qh MERGEexact= True; /* 'Qx' always */
-		}
-		qh_init_B(points, numpoints, dim, ismalloc);
-		qh_qhull();
-		qh_check_output();
-		qh_produce_output();
-		if (qh VERIFYoutput && !qh FORCEoutput && !qh STOPpoint && !qh STOPcone)
-			qh_check_points();
-		exitcode= qh_ERRnone;
-	}
-	qh NOerrexit= True;  /* no more setjmp */
-#ifdef qh_NOmem
-	qh_freeqhull( True);
-#else
-	qh_freeqhull( False);
-	qh_memfreeshort(&curlong, &totlong);
-	if (curlong || totlong)
-		fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory(%d pieces)\n",
-				totlong, curlong);
-#endif
-	#if defined(_WIN32) || defined(_WIN64)
-	rewind(fout);
-	fseek(fout, 0, SEEK_END);
-	size = ftell(fout);
-	rewind(fout);
-	bp = calloc(1, size + 1);
-
-	fread(bp, 1, size, fout);
-	bp[size] = '\0';
-	#endif
+        return NULL;
+    }
+    /* Now do the usual qhull code (modified from qvoronoi.c). */
+    qh_init_A(fin, fout, stderr, argc, argv);  /* sets qh qhull_command */
+    exitcode= setjmp(qh errexit); /* simple statement for CRAY J916 */
+    if (!exitcode) {
+        qh_option("Halfspace", NULL, NULL);
+        qh HALFspace= True;    /* 'H'   */
+        qh_checkflags(qh qhull_command, qhalf_hidden_options);
+        qh_initflags(qh qhull_command);
+        if (qh SCALEinput) {
+            fprintf(qh ferr, "\
+                    qhull error: options 'Qbk:n' and 'QBk:n' are not used with qhalf.\n\
+                    Use 'Qbk:0Bk:0 to drop dimension k.\n");
+            qh_errexit(qh_ERRinput, NULL, NULL);
+        }
+        points= qh_readpoints(&numpoints, &dim, &ismalloc);
+        if (dim >= 5) {
+            qh_option("Qxact_merge", NULL, NULL);
+            qh MERGEexact= True; /* 'Qx' always */
+        }
+        qh_init_B(points, numpoints, dim, ismalloc);
+        qh_qhull();
+        qh_check_output();
+        qh_produce_output();
+        if (qh VERIFYoutput && !qh FORCEoutput && !qh STOPpoint && !qh STOPcone)
+            qh_check_points();
+        exitcode= qh_ERRnone;
+    }
+    qh NOerrexit= True;  /* no more setjmp */
+    #ifdef qh_NOmem
+    qh_freeqhull( True);
+    #else
+    qh_freeqhull( False);
+    qh_memfreeshort(&curlong, &totlong);
+    if (curlong || totlong)
+        fprintf(stderr, "qhull internal warning (main): did not free %d bytes of long memory(%d pieces)\n",
+                totlong, curlong);
+    #endif
+    #if defined(_WIN32) || defined(_WIN64)
+    
+    rewind(fout);
+    fseek(fout, 0, SEEK_END);
+    size = ftell(fout);
+    rewind(fout);
+    bp = calloc(1, size + 1);
+    fread(bp, 1, size, fout);
+    bp[size] = '\0';
+    #endif
 
     fclose(fin);
     fclose(fout);
@@ -507,59 +506,53 @@ struct module_state {
 };
 
 #if PY_MAJOR_VERSION >= 3
-	#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+    #define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
 #else
-	#define GETSTATE(m) (&_state)
-	static struct module_state _state;
+    #define GETSTATE(m) (&_state)
+    static struct module_state _state;
 #endif
 
 #if PY_MAJOR_VERSION >= 3
 
-	static int _pyhull_traverse(PyObject *m, visitproc visit, void *arg) {
-		Py_VISIT(GETSTATE(m)->error);
-		return 0;
-	}
+    static int _pyhull_traverse(PyObject *m, visitproc visit, void *arg) {
+        Py_VISIT(GETSTATE(m)->error);
+        return 0;
+    }
 
-	static int _pyhull_clear(PyObject *m) {
-		Py_CLEAR(GETSTATE(m)->error);
-		return 0;
-	}
-
-
-	static struct PyModuleDef moduledef = {
-			PyModuleDef_HEAD_INIT,
-			"_pyhull",
-			NULL,
-			sizeof(struct module_state),
-			QhullMethods,
-			NULL,
-			_pyhull_traverse,
-			_pyhull_clear,
-			NULL
-	};
+    static int _pyhull_clear(PyObject *m) {
+        Py_CLEAR(GETSTATE(m)->error);
+        return 0;
+    }
 
 
-	#define INITERROR return NULL
+    static struct PyModuleDef moduledef = {
+            PyModuleDef_HEAD_INIT,
+            "_pyhull",
+            NULL,
+            sizeof(struct module_state),
+            QhullMethods,
+            NULL,
+            _pyhull_traverse,
+            _pyhull_clear,
+            NULL
+    };
+
+    #define INITERROR return NULL
 
 #else
-	
-
-
-		#define INITERROR return
-
-
+    #define INITERROR return
 #endif
 
 
 #if PY_MAJOR_VERSION >= 3
-	PyMODINIT_FUNC PyInit__pyhull(void)
-	{
-		PyObject *module = PyModule_Create(&moduledef);
-		return module;
-	}
+PyMODINIT_FUNC PyInit__pyhull(void)
+{
+    PyObject *module = PyModule_Create(&moduledef);
+    return module;
+}
 #else
-	void init_pyhull(void)
-	{
-		(void) Py_InitModule("_pyhull", QhullMethods);
-	}
+void init_pyhull(void)
+{
+    (void) Py_InitModule("_pyhull", QhullMethods);
+}
 #endif

--- a/src/_pyhull.c
+++ b/src/_pyhull.c
@@ -526,15 +526,15 @@ static int _pyhull_clear(PyObject *m) {
 
 
 static struct PyModuleDef moduledef = {
-		PyModuleDef_HEAD_INIT,
-		"_pyhull",
-		NULL,
-		sizeof(struct module_state),
-		QhullMethods,
-		NULL,
-		_pyhull_traverse,
-		_pyhull_clear,
-		NULL
+	PyModuleDef_HEAD_INIT,
+	"_pyhull",
+	NULL,
+	sizeof(struct module_state),
+	QhullMethods,
+	NULL,
+	_pyhull_traverse,
+	_pyhull_clear,
+	NULL
 };
 
 #define INITERROR return NULL


### PR DESCRIPTION
**Changes**

- `__attribute__((visibility("default")))` was replaced to make non GNU compiler accept the file
- in order to make it work on Windows `fmemopen` and `open_memstream` were replaced with Windows specific functions. `CreateFileA` should only create in-memory files unless the files become too big.
- the biggest apparent change is due to `if ((fin != NULL) && (fout != NULL))` became `    if ((fin == NULL) || (fout == NULL))` to get rid of one level of indentation and the `else` block. This doesn't change any of the code or logic.
- whitespace: cleanup

**Testing**

1. Ubuntu
- Compiles and runs on Ubuntu 16.04 LTS with Python 2.7 and 3.5, no apparent change in the run time for the unit tests
2. Windows 10
- Python 2.5: using Microsoft Visual C++ Compiler for Python 2.7
- Python 3.5: using Visual Studio 2015
- Python 3.7: using Visual Studio 2015

**Run times**

1. Ubuntu laptop (i5-2520M, 2.50 GHz)
- Python 2.7: ~20 msec for 24 tests
- Python 3.5: ~25 msec for 24 tests
2. Windows (i5-2500, 3.30 GHz)
- Python 2.7: ~125 msec for 24 tests
- Python 3.5: ~120 msec for 24 tests
- Python 3.7: ~120 msec for 24 tests

Tests were run with `python -m unittest discover`
